### PR TITLE
change package.json to reflect this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,23 +2,19 @@
   "name": "labs-design-styleguide-starter",
   "version": "1.0.0",
   "description": "A starter project for spinning up a living styleguide",
-  "main": "index.js",
-  "directories": {
-    "doc": "docs"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trulia/hologram-example.git"
+    "url": "git+https://github.com/mattrothenberg/styleguide-boilerplate"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/trulia/hologram-example/issues"
+    "url": "https://github.com/mattrothenberg/styleguide-boilerplate"
   },
-  "homepage": "https://github.com/trulia/hologram-example#readme",
+  "homepage": "https://github.com/mattrothenberg/styleguide-boilerplate",
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",


### PR DESCRIPTION
Just changing the package.json file to reflect that this is the main repo. Will be nice too if we want to someday have our own npm package (e.g. `npm install labs-design-styleguide-starter`).
