### PR TITLE
Add gulp deploy task + gulp exec

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,4 +62,4 @@ gulp.task('deploy', shell.task([
 ]));
 
 
-gulp.task('default', ['open', 'sass', 'hologram', 'connect', 'watch', 'deploy' ])
+gulp.task('default', ['open', 'sass', 'hologram', 'connect', 'watch' ])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var os = require('os');
 var sass = require('gulp-sass');
 var shell = require('gulp-shell');
 var sourcemaps = require('gulp-sourcemaps');
+var exec = require('gulp-exec');
 
 var browser = os.platform() === 'linux' ? 'google-chrome' : (
   os.platform() === 'darwin' ? 'google chrome' : (
@@ -56,5 +57,9 @@ gulp.task('html', function () {
     .pipe(connect.reload());
 });
 
+gulp.task('deploy', shell.task([
+    'cf push'
+]));
 
-gulp.task('default', ['open', 'sass', 'hologram', 'connect', 'watch', ])
+
+gulp.task('default', ['open', 'sass', 'hologram', 'connect', 'watch', 'deploy' ])

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp-open": "^2.0.0",
     "gulp-sass": "^2.3.2",
     "gulp-shell": "^0.5.2",
-    "gulp-sourcemaps": "^1.6.0"
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-exec": "^3.10.8"
   }
 }


### PR DESCRIPTION
- `gulp deploy` in this PR is an alias for `cf push`  
- Added `gulp-exec`

_Note:_ `gulp-shell` is on the [Gulp's blacklist](https://github.com/gulpjs/plugins/blob/master/src/blackList.json) because it promotes anti-patterns. Let's keep it in and re-evaluate in the future.
