### PR TITLE
Add debug CSS function

### DIFF
--- a/styleguide-theme/_footer.html
+++ b/styleguide-theme/_footer.html
@@ -14,5 +14,6 @@
   <script src="static/js/zenscroll-min.js"></script>
   <script src="static/js/gumshoe-min.js"></script>
   <script src="static/js/scripts.js"></script>
+  <script src="static/js/debug_css.js"></script>
 </body>
 </html>

--- a/styleguide-theme/static/js/debug_css.js
+++ b/styleguide-theme/static/js/debug_css.js
@@ -1,0 +1,3 @@
+function debugCss() {
+  [].forEach.call($$("*"),function(a){a.style.outline="1px solid #"+(~~(Math.random()*(1<<24))).toString(16)})
+}


### PR DESCRIPTION
In console write `debugCss()`

It will outline all elements on the current page. This could be a useful utility to debug CSS or to show the structure of a component. Thoughts?

[![debug_css.png](https://s21.postimg.org/eyq182mp3/debug_css.png)](https://postimg.org/image/ygkoo0jmr/)